### PR TITLE
fix: unpin `openssh-server` version

### DIFF
--- a/other/openssh/manifest.yml
+++ b/other/openssh/manifest.yml
@@ -9,12 +9,12 @@ nature: solo
 type: other
 description: OpenSSH is the premier connectivity tool for remote login with the SSH protocol. It encrypts all traffic to eliminate eavesdropping, connection hijacking, and other attacks. In addition, OpenSSH provides a large suite of secure tunneling capabilities, several authentication methods, and sophisticated configuration options.
 versions:
-  - 8.4p1-5
+  - latest
 portBindings:
   - 22/tcp
 startCmd: /usr/sbin/sshd -D
 installCmdSteps:
   - mkdir -p /var/run/sshd
-  - install_packages openssh-server=1:%version%+deb11u3
+  - install_packages openssh-server
 estimatedSizeBytes: 1760000
 avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/other/openssh/assets/avatar.jpg


### PR DESCRIPTION
This pull request includes a small but significant change to the `other/openssh/manifest.yml` file. The change updates the version of OpenSSH being installed to always use the latest version.

* [`other/openssh/manifest.yml`](diffhunk://#diff-2e47a7b2e8b460fdc70242e585e61e839eba5a81cb79f04d2ee7d48f1ab557ffL12-R18): Changed the OpenSSH version from a specific version `8.4p1-5` to `latest` to ensure the most recent version is always installed.