### PR TITLE
chore: open mariadb connection to the world

### DIFF
--- a/database/mariadb/manifest.yaml
+++ b/database/mariadb/manifest.yaml
@@ -19,6 +19,7 @@ installCmdSteps:
   - if [ ! -f "/usr/bin/mysql" ]; then ln -s /usr/bin/mariadb /usr/bin/mysql; fi
   - if [ ! -f "/usr/bin/mariadb-admin" ]; then ln -s /usr/bin/mariadb-admin /usr/bin/mysqladmin; fi
   - if [ ! -f "/usr/bin/mariadbd-safe" ]; then ln -s /usr/bin/mariadbd-safe /usr/bin/mysqld_safe; fi
+  - sed -i 's/^bind-address.*/bind_address = 0.0.0.0/' /etc/mysql/mariadb.conf.d/50-server.cnf
   - mariadbd-safe --no-watch --skip-grant-tables && sleep 5
   - mariadb --protocol=socket -e "FLUSH PRIVILEGES; ALTER USER 'root'@'localhost' IDENTIFIED BY '%randomPassword%'; DELETE FROM mysql.user WHERE User=''; DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1'); DROP DATABASE IF EXISTS test; DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'; FLUSH PRIVILEGES;"
   - echo -e "[client]\nuser=root\npassword='%randomPassword%'\n" >/root/.my.cnf


### PR DESCRIPTION
This pull request changes the `database/mariadb/manifest.yaml` file to open MariaDB to the world, by ensuring that MariaDB binds to all network interfaces.

Configuration modified:

* [`database/mariadb/manifest.yaml`](diffhunk://#diff-020b754e563b9d44a66f44fc42af9e15a7f7c7fe04228caf2288bb253dc3b92aR22): Added a command to update the `bind-address` setting in the MariaDB configuration file to `0.0.0.0`, allowing MariaDB to accept connections from any network interface.