### PR TITLE
fix: images path now uses github pages

### DIFF
--- a/database/mariadb/manifest.yaml
+++ b/database/mariadb/manifest.yaml
@@ -43,4 +43,4 @@ stopCmdSteps:
   - mariadb-admin --defaults-file=/root/.my.cnf shutdown
 execUser: mysql
 estimatedSizeBytes: 524288000
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/database/mariadb/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/database/mariadb/assets/avatar.jpg

--- a/database/opensearch/manifest.json
+++ b/database/opensearch/manifest.json
@@ -65,5 +65,5 @@
   ],
   "execUser": "opensearch",
   "estimatedSizeBytes": 1182262233,
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/database/opensearch/assets/avatar.jpg"
+  "avatarUrl": "https://goinfinite.github.io/os-services/database/opensearch/assets/avatar.jpg"
 }

--- a/database/postgresql/manifest.json
+++ b/database/postgresql/manifest.json
@@ -46,5 +46,5 @@
   ],
   "execUser": "postgres",
   "estimatedSizeBytes": "367001600",
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/database/postgresql/assets/avatar.jpg"
+  "avatarUrl": "https://goinfinite.github.io/os-services/database/postgresql/assets/avatar.jpg"
 }

--- a/database/redis/manifest.yaml
+++ b/database/redis/manifest.yaml
@@ -35,4 +35,4 @@ uninstallFilePaths:
   - /run/redis/
 execUser: redis
 estimatedSizeBytes: 15728640
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/database/redis/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/database/redis/assets/avatar.jpg

--- a/other/openssh/manifest.yml
+++ b/other/openssh/manifest.yml
@@ -17,4 +17,4 @@ installCmdSteps:
   - mkdir -p /var/run/sshd
   - install_packages openssh-server
 estimatedSizeBytes: 1760000
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/other/openssh/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/other/openssh/assets/avatar.jpg

--- a/runtime/java/manifest.yaml
+++ b/runtime/java/manifest.yaml
@@ -287,4 +287,4 @@ installCmdSteps:
   - if [ ! -f "%startupFile%" ]; then install -o nobody -g nogroup /dev/null %startupFile%; fi
   - if [ ! -s "%startupFile%" ]; then echo 'import com.sun.net.httpserver.HttpServer; import java.net.InetSocketAddress; public class SimpleHttpServer { public static void main(String[] args) throws Exception { HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0); server.start(); } }' >%startupFile%; fi
 estimatedSizeBytes: 362735572
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/runtime/java/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/runtime/java/assets/avatar.jpg

--- a/runtime/node/manifest.yml
+++ b/runtime/node/manifest.yml
@@ -36,4 +36,4 @@ installCmdSteps:
   - if [ ! -f "%startupFile%" ]; then install -o nobody -g nogroup /dev/null %startupFile%; fi
   - if [ ! -s "%startupFile%" ]; then echo "require('http').createServer((req, res) => res.end()).listen(3000)" >%startupFile%; fi
 estimatedSizeBytes: 104857600
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/runtime/node/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/runtime/node/assets/avatar.jpg

--- a/runtime/php-webserver/manifest.yml
+++ b/runtime/php-webserver/manifest.yml
@@ -34,4 +34,4 @@ stopCmdSteps:
   - sleep 1; if pgrep litespeed >/dev/null; then /usr/local/lsws/bin/lswsctrl stop; fi
   - if pgrep lsphp >/dev/null; then pkill lsphp; fi
 estimatedSizeBytes: 157286400
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-services/refs/heads/v1/runtime/php-webserver/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-services/runtime/php-webserver/assets/avatar.jpg


### PR DESCRIPTION
This pull request updates the URLs for avatar images and screenshots across multiple application manifest files to use the goinfinite.github.io domain instead of raw.githubusercontent.com. This change ensures a more consistent and reliable hosting source for these assets.