### PR TITLE
chore: update node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## v1
 
 ```
+# 2025/12/05
+
+chore: update node versions
+```
+
+```
 # 2025/07/30
 
 feat: add python runtime

--- a/runtime/node/manifest.yml
+++ b/runtime/node/manifest.yml
@@ -8,6 +8,9 @@ type: runtime
 description: Node.js runs on the V8 JavaScript engine and lets developers use JavaScript to write command line tools and for server-side scripting.
 versions:
   - lts
+  - 25
+  - 24
+  - 23
   - 22
   - 21
   - 20


### PR DESCRIPTION
This pull request updates the supported Node.js versions in the `runtime/node/manifest.yml` file by adding the latest releases.

Node.js runtime updates:

* Added support for Node.js versions 25, 24, and 23 to the `versions` list in `runtime/node/manifest.yml`.