### PR TITLE
feat: add port binding 8644/http for hermes-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v1
 
 ```
+# 2026/04/16
+
+feat: add port binding 8644/http for hermes-agent (PR #65)
+
 # 2026/04/14
 
 feat: add hermes-agent

--- a/other/hermes-agent/manifest.yml
+++ b/other/hermes-agent/manifest.yml
@@ -9,6 +9,7 @@ description: Hermes is a self-improving AI agent by Nous Research. It creates sk
 versions:
   - v2026.4.13
 portBindings:
+  - 8644/http
 startCmd: /root/.local/bin/hermes gateway run
 installCmdSteps:
   - install_packages -qqy ripgrep


### PR DESCRIPTION
## Summary
- Add port binding `8644/http` to hermes-agent manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added HTTP port 8644 binding to service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->