### PR TITLE
fix: remove maxscale repository from mariadb setup

### DIFF
--- a/database/mariadb/manifest.yaml
+++ b/database/mariadb/manifest.yaml
@@ -15,6 +15,7 @@ portBindings:
 startCmd: /usr/bin/mariadbd-safe
 installCmdSteps:
   - curl -skL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version=%version%
+  - sed -i '/# MariaDB MaxScale/,/^$/d' /etc/apt/sources.list.d/mariadb.list
   - install_packages mariadb-server mariadb-client
   - if [ ! -f "/usr/bin/mysql" ]; then ln -s /usr/bin/mariadb /usr/bin/mysql; fi
   - if [ ! -f "/usr/bin/mariadb-admin" ]; then ln -s /usr/bin/mariadb-admin /usr/bin/mysqladmin; fi


### PR DESCRIPTION
Closes #66

The `mariadb_repo_setup` script adds three repositories by default: MariaDB Server, MaxScale, and MariaDB Tools. MaxScale is a proxy/load balancer for multi-node HA setups, which is not part of our stack.

Having the MaxScale repo without its GPG key imported causes `apt update` to fail with a signature verification warning, blocking package upgrades.

## Change

Add a `sed` command after the repo setup to strip the MaxScale block from the generated list file:

```yaml
- sed -i '/# MariaDB MaxScale/,/^$/d' /etc/apt/sources.list.d/mariadb.list
```

## QA Result

Tested in a fresh Infinite OS container (`docker.io/goinfinite/os:0.2.7.1`). All 10 test cases passed:
- Installation completes without errors
- `/etc/apt/sources.list.d/mariadb.list` no longer contains the MaxScale repo block
- `apt update` runs successfully with no GPG/signature verification errors
- MariaDB service starts correctly and is accessible on port 3306
- Uninstall and cleanup work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced MariaDB installation configuration to ensure proper cleanup of package source settings for more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->