### PR TITLE
feat: add MariaDB 11.8 and 12.3 LTS versions

### DIFF
--- a/database/mariadb/manifest.yaml
+++ b/database/mariadb/manifest.yaml
@@ -7,6 +7,8 @@ nature: solo
 type: database
 description: MariaDB is a community-developed, commercially supported fork of the MySQL relational database management system, intended to remain free and open-source software under the GNU General Public License.
 versions:
+  - 12.3
+  - 11.8
   - 11.4
   - 10.11
   - 10.6


### PR DESCRIPTION
Closes #69

## Changes
- Add **11.8** (LTS, EOL 2028) to versions list
- Add **12.3** (LTS, EOL 2029) to versions list
- No removals — 11.4, 10.11, 10.6 remain supported

## QA
| Version | Tests | Result |
|---------|-------|--------|
| 11.8 | 8/8 (install, start, port, DB, uninstall, cleanup) | PASS |
| 12.3 | Pre-flight install + connectivity | PASS |

Tested in `goinfinite/os:0.2.9` container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * MariaDB: Added support for versions 12.3 and 11.8. The platform now supports MariaDB versions 12.3, 11.8, 11.4, 10.11, and 10.6, allowing users to enjoy significantly expanded version compatibility and greater flexibility when selecting, deploying, upgrading, and managing their database instances across various infrastructure environments, deployment strategies, operational scenarios, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->