### PR TITLE
fix: handle both mariadb.list and mariadb.sources for MaxScale removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v1
 
 ```
+# 2026/07/03
+
+fix: handle both mariadb.list and mariadb.sources for MaxScale removal (Issue #71)
+
 # 2026/04/16
 
 feat: add port binding 8644/http for hermes-agent (PR #65)

--- a/database/mariadb/manifest.yaml
+++ b/database/mariadb/manifest.yaml
@@ -17,7 +17,7 @@ portBindings:
 startCmd: /usr/bin/mariadbd-safe
 installCmdSteps:
   - curl -skL https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version=%version%
-  - sed -i '/# MariaDB MaxScale/,/^$/d' /etc/apt/sources.list.d/mariadb.list
+  - for f in /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/mariadb.sources; do [ -f "$f" ] && sed -i '/# MariaDB MaxScale/,/^$/d' "$f"; done
   - install_packages mariadb-server mariadb-client
   - if [ ! -f "/usr/bin/mysql" ]; then ln -s /usr/bin/mariadb /usr/bin/mysql; fi
   - if [ ! -f "/usr/bin/mariadb-admin" ]; then ln -s /usr/bin/mariadb-admin /usr/bin/mysqladmin; fi
@@ -41,6 +41,7 @@ uninstallFilePaths:
   - /var/lib/mysql
   - /var/log/mysql
   - /etc/apt/sources.list.d/mariadb.list
+  - /etc/apt/sources.list.d/mariadb.sources
   - /root/.my.cnf
 stopCmdSteps:
   - mariadb-admin --defaults-file=/root/.my.cnf shutdown


### PR DESCRIPTION
Closes #71

## What changed

The MariaDB repository setup script (`mariadb_repo_setup`) now uses the new DEB822 format, writing to `/etc/apt/sources.list.d/mariadb.sources` instead of the legacy `mariadb.list`.

### Changes in `database/mariadb/manifest.yaml`

- **installCmdSteps**: replaced hardcoded `sed -i ... mariadb.list` with a for-loop that applies the MaxScale removal to whichever file exists (both `.list` and `.sources`)
- **uninstallFilePaths**: added `/etc/apt/sources.list.d/mariadb.sources`

### How it works

```bash
for f in /etc/apt/sources.list.d/mariadb.list /etc/apt/sources.list.d/mariadb.sources; do
  [ -f  ] && sed -i '/# MariaDB MaxScale/,/^$/d' 
done
```

The `[ -f  ]` guard ensures the sed only runs on files that actually exist — no errors regardless of which format the setup script produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MariaDB MaxScale removal so both repository formats are handled consistently.
  * Uninstalling MariaDB now cleans up all related repository entries more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->