### PR TITLE
fix: add PHP session garbage collection params to primary.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v1
 
 ```
+# 2026/07/21
+
+fix: add PHP session garbage collection params to primary.conf (Issue #329)
+
 # 2026/07/03
 
 fix: handle both mariadb.list and mariadb.sources for MaxScale removal (Issue #71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ```
 # 2026/07/21
 
-fix: add PHP session garbage collection params to primary.conf (Issue #329)
+fix: add PHP session garbage collection params to primary.conf (Issue #73)
 
 # 2026/07/03
 

--- a/runtime/php-webserver/assets/primary.conf
+++ b/runtime/php-webserver/assets/primary.conf
@@ -50,6 +50,8 @@ php_value memory_limit 128M
 php_value post_max_size 16M
 php_flag session.auto_start Off
 php_value session.cookie_lifetime 0
+php_value session.gc_probability 1
+php_value session.gc_divisor 1000
 php_value session.gc_maxlifetime 1800
 php_value session.name "PHPSESSID"
 php_value session.save_handler files


### PR DESCRIPTION
Closes #73

Adds `session.gc_probability` and `session.gc_divisor` to the PHP WebServer primary.conf to ensure session garbage collection runs correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added PHP session garbage-collection settings to improve cleanup of expired sessions.
  * Corrected web server configuration syntax for more reliable request rewriting.

* **Documentation**
  * Added a changelog entry describing the configuration fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->